### PR TITLE
Use stable mirrors for release downloads

### DIFF
--- a/.github/workflows/integration_test.yaml
+++ b/.github/workflows/integration_test.yaml
@@ -33,11 +33,11 @@ jobs:
       - name: Run Target Action
         uses: ./
         with:
-          yq: '2.4.1'
+          yq: '4.53.2'
 
       - name: Check Version
         run: |
-          test "$(yq --version)" == "yq version 2.4.1"
+          yq --version | grep "version v4.53.2"
 
   test_kubectl:
     name: Run Test (kubectl)
@@ -128,8 +128,8 @@ jobs:
       - name: Run Target Action
         uses: ./
         with:
-          hub: '2.14.0'
+          hub: '2.14.2'
 
       - name: Check Version
         run: |
-          test "$(hub version |grep hub)" == "hub version 2.14.0"
+          test "$(hub version |grep hub)" == "hub version 2.14.2"

--- a/__test__/installers/hub-url.test.ts
+++ b/__test__/installers/hub-url.test.ts
@@ -1,0 +1,25 @@
+import { getTarballBinary } from '../../src/installers/utils';
+import { HubInstaller } from '../../src/installers/hub';
+
+jest.mock('os', () => ({
+  ...jest.requireActual('os'),
+  arch: jest.fn(() => 'x64'),
+  platform: jest.fn(() => 'linux'),
+}));
+
+jest.mock('../../src/installers/utils', () => ({
+  getTarballBinary: jest.fn().mockResolvedValue('/tmp/hub'),
+}));
+
+describe('hub download URL', () => {
+  it('downloads hub from the SourceForge mirror', async () => {
+    await new HubInstaller().install('2.14.2');
+
+    expect(getTarballBinary).toHaveBeenCalledWith(
+      'hub',
+      '2.14.2',
+      'https://sourceforge.net/projects/hub.mirror/files/v2.14.2/hub-linux-amd64-2.14.2.tgz/download',
+      'hub-linux-amd64-2.14.2/bin',
+    );
+  });
+});

--- a/__test__/installers/jq-url.test.ts
+++ b/__test__/installers/jq-url.test.ts
@@ -1,0 +1,24 @@
+import { JqInstaller } from '../../src/installers/jq';
+import { getBinary } from '../../src/installers/utils';
+
+jest.mock('os', () => ({
+  ...jest.requireActual('os'),
+  arch: jest.fn(() => 'x64'),
+  platform: jest.fn(() => 'linux'),
+}));
+
+jest.mock('../../src/installers/utils', () => ({
+  getBinary: jest.fn().mockResolvedValue('/tmp/jq'),
+}));
+
+describe('jq download URL', () => {
+  it('downloads jq from the SourceForge mirror', async () => {
+    await new JqInstaller().install('1.6');
+
+    expect(getBinary).toHaveBeenCalledWith(
+      'jq',
+      '1.6',
+      'https://sourceforge.net/projects/stedolan-jq.mirror/files/jq-1.6/jq-linux64/download',
+    );
+  });
+});

--- a/__test__/installers/kustomize-url.test.ts
+++ b/__test__/installers/kustomize-url.test.ts
@@ -1,0 +1,76 @@
+import { getTarballBinary } from '../../src/installers/utils';
+import { KustomizeInstaller } from '../../src/installers/kustomize';
+import * as https from 'https';
+
+jest.mock('os', () => ({
+  ...jest.requireActual('os'),
+  arch: jest.fn(() => 'x64'),
+  platform: jest.fn(() => 'linux'),
+}));
+
+jest.mock('../../src/installers/utils', () => ({
+  getTarballBinary: jest.fn().mockResolvedValue('/tmp/kustomize'),
+}));
+
+jest.mock('https', () => ({
+  get: jest.fn(),
+}));
+
+describe('kustomize download URL', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (https.get as jest.Mock).mockImplementation((url, options, callback) => {
+      let response: any;
+      response = {
+        on: jest.fn((event: string, handler: (data?: string) => void) => {
+          if (event === 'data') {
+            handler(
+              JSON.stringify({
+                assets: [
+                  {
+                    id: 17272155,
+                    name: 'kustomize_v3.5.4_linux_amd64.tar.gz',
+                  },
+                ],
+              }),
+            );
+          }
+
+          if (event === 'end') {
+            handler();
+          }
+
+          return response;
+        }),
+        setEncoding: jest.fn(),
+        statusCode: 200,
+      };
+
+      callback(response);
+
+      return { on: jest.fn() };
+    });
+  });
+
+  it('downloads kustomize from the official GitHub release asset API', async () => {
+    await new KustomizeInstaller().install('3.5.4');
+
+    expect(https.get).toHaveBeenCalledWith(
+      'https://api.github.com/repos/kubernetes-sigs/kustomize/releases/tags/kustomize%2Fv3.5.4',
+      {
+        headers: {
+          Accept: 'application/vnd.github+json',
+          'User-Agent': 'coscene-io/setup-cd-tools',
+        },
+      },
+      expect.any(Function),
+    );
+    expect(getTarballBinary).toHaveBeenCalledWith('kustomize', '3.5.4', {
+      headers: {
+        Accept: 'application/octet-stream',
+      },
+      url: 'https://api.github.com/repos/kubernetes-sigs/kustomize/releases/assets/17272155',
+    });
+  });
+});

--- a/__test__/installers/skaffold-url.test.ts
+++ b/__test__/installers/skaffold-url.test.ts
@@ -1,0 +1,24 @@
+import { SkaffoldInstaller } from '../../src/installers/skaffold';
+import { getBinary } from '../../src/installers/utils';
+
+jest.mock('os', () => ({
+  ...jest.requireActual('os'),
+  arch: jest.fn(() => 'x64'),
+  platform: jest.fn(() => 'linux'),
+}));
+
+jest.mock('../../src/installers/utils', () => ({
+  getBinary: jest.fn().mockResolvedValue('/tmp/skaffold'),
+}));
+
+describe('skaffold download URL', () => {
+  it('downloads skaffold from the official GCS release bucket', async () => {
+    await new SkaffoldInstaller().install('2.3.1');
+
+    expect(getBinary).toHaveBeenCalledWith(
+      'skaffold',
+      '2.3.1',
+      'https://storage.googleapis.com/skaffold/releases/v2.3.1/skaffold-linux-amd64',
+    );
+  });
+});

--- a/__test__/installers/utils-retry.test.ts
+++ b/__test__/installers/utils-retry.test.ts
@@ -9,6 +9,7 @@ jest.mock('@actions/tool-cache', () => ({
   cacheFile: jest.fn().mockResolvedValue('/tmp/cache'),
   downloadTool: jest.fn(),
   extractTar: jest.fn().mockResolvedValue('/tmp/extracted'),
+  extractZip: jest.fn().mockResolvedValue('/tmp/extracted-zip'),
   find: jest.fn().mockReturnValue(''),
 }));
 
@@ -22,6 +23,7 @@ describe('installer download retries', () => {
     jest.clearAllMocks();
     (tc.find as jest.Mock).mockReturnValue('');
     (tc.extractTar as jest.Mock).mockResolvedValue('/tmp/extracted');
+    (tc.extractZip as jest.Mock).mockResolvedValue('/tmp/extracted-zip');
     (tc.cacheFile as jest.Mock).mockResolvedValue('/tmp/cache');
   });
 
@@ -36,6 +38,21 @@ describe('installer download retries', () => {
     expect(tc.extractTar).toHaveBeenCalledWith('/tmp/download.tgz');
     expect(tc.cacheFile).toHaveBeenCalledWith(
       '/tmp/extracted/hub',
+      'hub',
+      'hub',
+      '2.14.2',
+    );
+  });
+
+  it('extracts zip downloads with the zip extractor', async () => {
+    (tc.downloadTool as jest.Mock).mockResolvedValueOnce('/tmp/download.zip');
+
+    await getTarballBinary('hub', '2.14.2', 'https://example.test/hub.zip');
+
+    expect(tc.extractZip).toHaveBeenCalledWith('/tmp/download.zip');
+    expect(tc.extractTar).not.toHaveBeenCalled();
+    expect(tc.cacheFile).toHaveBeenCalledWith(
+      '/tmp/extracted-zip/hub',
       'hub',
       'hub',
       '2.14.2',

--- a/__test__/installers/utils-retry.test.ts
+++ b/__test__/installers/utils-retry.test.ts
@@ -58,4 +58,24 @@ describe('installer download retries', () => {
       '2.14.2',
     );
   });
+
+  it('falls back to the next tarball URL after retries are exhausted', async () => {
+    (tc.downloadTool as jest.Mock)
+      .mockRejectedValueOnce(new Error('Unexpected HTTP response: 504'))
+      .mockRejectedValueOnce(new Error('Unexpected HTTP response: 504'))
+      .mockResolvedValueOnce('/tmp/fallback.tgz');
+
+    await getTarballBinary('kustomize', '3.5.4', [
+      'https://example.test/kustomize.tgz',
+      'https://fallback.example.test/kustomize.tgz',
+    ]);
+
+    expect(tc.downloadTool).toHaveBeenCalledWith(
+      'https://example.test/kustomize.tgz',
+    );
+    expect(tc.downloadTool).toHaveBeenCalledWith(
+      'https://fallback.example.test/kustomize.tgz',
+    );
+    expect(tc.extractTar).toHaveBeenCalledWith('/tmp/fallback.tgz');
+  });
 });

--- a/__test__/installers/utils-retry.test.ts
+++ b/__test__/installers/utils-retry.test.ts
@@ -1,0 +1,44 @@
+import * as tc from '@actions/tool-cache';
+import { getTarballBinary } from '../../src/installers/utils';
+
+jest.mock('@actions/core', () => ({
+  debug: jest.fn(),
+}));
+
+jest.mock('@actions/tool-cache', () => ({
+  cacheFile: jest.fn().mockResolvedValue('/tmp/cache'),
+  downloadTool: jest.fn(),
+  extractTar: jest.fn().mockResolvedValue('/tmp/extracted'),
+  find: jest.fn().mockReturnValue(''),
+}));
+
+jest.mock('fs', () => ({
+  ...jest.requireActual('fs'),
+  chmodSync: jest.fn(),
+}));
+
+describe('installer download retries', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (tc.find as jest.Mock).mockReturnValue('');
+    (tc.extractTar as jest.Mock).mockResolvedValue('/tmp/extracted');
+    (tc.cacheFile as jest.Mock).mockResolvedValue('/tmp/cache');
+  });
+
+  it('retries a tarball download when the first download attempt fails', async () => {
+    (tc.downloadTool as jest.Mock)
+      .mockRejectedValueOnce(new Error('Unexpected HTTP response: 504'))
+      .mockResolvedValueOnce('/tmp/download.tgz');
+
+    await getTarballBinary('hub', '2.14.2', 'https://example.test/hub.tgz');
+
+    expect(tc.downloadTool).toHaveBeenCalledTimes(2);
+    expect(tc.extractTar).toHaveBeenCalledWith('/tmp/download.tgz');
+    expect(tc.cacheFile).toHaveBeenCalledWith(
+      '/tmp/extracted/hub',
+      'hub',
+      'hub',
+      '2.14.2',
+    );
+  });
+});

--- a/__test__/installers/yq-url.test.ts
+++ b/__test__/installers/yq-url.test.ts
@@ -1,0 +1,24 @@
+import { getBinary } from '../../src/installers/utils';
+import { YqInstaller } from '../../src/installers/yq';
+
+jest.mock('os', () => ({
+  ...jest.requireActual('os'),
+  arch: jest.fn(() => 'x64'),
+  platform: jest.fn(() => 'linux'),
+}));
+
+jest.mock('../../src/installers/utils', () => ({
+  getBinary: jest.fn().mockResolvedValue('/tmp/yq'),
+}));
+
+describe('yq download URL', () => {
+  it('downloads yq from the SourceForge mirror', async () => {
+    await new YqInstaller().install('4.53.2');
+
+    expect(getBinary).toHaveBeenCalledWith(
+      'yq',
+      '4.53.2',
+      'https://sourceforge.net/projects/yq-yq.mirror/files/v4.53.2/yq_linux_amd64/download',
+    );
+  });
+});

--- a/__test__/installers/yq.test.ts
+++ b/__test__/installers/yq.test.ts
@@ -9,7 +9,7 @@ const IS_WINDOWS = process.platform === 'win32';
 describe('yq installer tests', () => {
   const installer = new YqInstaller();
 
-  const versions = ['2.3.0'];
+  const versions = ['4.53.2'];
 
   for (const version of versions) {
     it('Acquires the specified version of yq', async () => {

--- a/dist/index.js
+++ b/dist/index.js
@@ -28567,7 +28567,7 @@ function getDownloadUrl(version) {
     if (!filename) {
         throw `Unsupported platform. platform:${os.platform()}, arch:${os.arch()}`;
     }
-    return `https://github.com/stedolan/jq/releases/download/jq-${version}/${filename}`;
+    return `https://sourceforge.net/projects/stedolan-jq.mirror/files/jq-${version}/${filename}/download`;
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -28886,6 +28886,7 @@ const tc = __importStar(__nccwpck_require__(3472));
 const os = __importStar(__nccwpck_require__(857));
 const fs = __importStar(__nccwpck_require__(9896));
 const path = __importStar(__nccwpck_require__(6928));
+const downloadAttempts = 2;
 function getBinary(toolName, version, url) {
     return __awaiter(this, void 0, void 0, function* () {
         let cachedToolpath;
@@ -28894,7 +28895,7 @@ function getBinary(toolName, version, url) {
             core.debug(`Downloading ${toolName} from: ${url}`);
             let downloadPath = null;
             try {
-                downloadPath = yield tc.downloadTool(url);
+                downloadPath = yield downloadToolWithRetries(url);
             }
             catch (error) {
                 throw `Failed to download version ${version}: ${error}`;
@@ -28914,7 +28915,7 @@ function getTarballBinary(toolName_1, version_1, url_1) {
             core.debug(`Downloading ${toolName} from: ${url}`);
             let downloadPath = null;
             try {
-                downloadPath = yield tc.downloadTool(url);
+                downloadPath = yield downloadToolWithRetries(url);
             }
             catch (error) {
                 throw `Failed to download version ${version}: ${error}`;
@@ -28938,6 +28939,23 @@ function getExecutableExtension() {
         return '.exe';
     }
     return '';
+}
+function downloadToolWithRetries(url) {
+    return __awaiter(this, void 0, void 0, function* () {
+        let lastError;
+        for (let attempt = 1; attempt <= downloadAttempts; attempt++) {
+            try {
+                return yield tc.downloadTool(url);
+            }
+            catch (error) {
+                lastError = error;
+                if (attempt < downloadAttempts) {
+                    core.debug(`Retrying download from ${url}`);
+                }
+            }
+        }
+        throw lastError;
+    });
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -28824,7 +28824,7 @@ function getDownloadUrl(version) {
     if (!arch || !platform) {
         throw `Unsupported platform. platform:${os.platform()}, arch:${os.arch()}`;
     }
-    return `https://github.com/GoogleContainerTools/skaffold/releases/download/v${version}/skaffold-${platform}-${arch}${extension}`;
+    return `https://storage.googleapis.com/skaffold/releases/v${version}/skaffold-${platform}-${arch}${extension}`;
 }
 
 

--- a/dist/index.js
+++ b/dist/index.js
@@ -28722,14 +28722,16 @@ var __awaiter = (this && this.__awaiter) || function (thisArg, _arguments, P, ge
 Object.defineProperty(exports, "__esModule", ({ value: true }));
 exports.KustomizeInstaller = void 0;
 const core = __importStar(__nccwpck_require__(7484));
+const https = __importStar(__nccwpck_require__(5692));
 const os = __importStar(__nccwpck_require__(857));
 const path = __importStar(__nccwpck_require__(6928));
 const utils_1 = __nccwpck_require__(1008);
 const toolName = 'kustomize';
+const userAgent = 'coscene-io/setup-cd-tools';
 class KustomizeInstaller {
     install(version) {
         return __awaiter(this, void 0, void 0, function* () {
-            const url = getDownloadUrl(version);
+            const url = yield getDownloadUrl(version);
             const kustomizePath = yield (0, utils_1.getTarballBinary)(toolName, version, url);
             core.debug(`kustomize has been cached at ${kustomizePath}`);
             core.addPath(path.dirname(kustomizePath));
@@ -28738,20 +28740,64 @@ class KustomizeInstaller {
 }
 exports.KustomizeInstaller = KustomizeInstaller;
 function getDownloadUrl(version) {
-    let platformMap = {
-        linux: 'linux',
-        darwin: 'darwin',
-        win32: 'windows',
-    };
-    let archMap = {
-        x64: 'amd64',
-    };
-    const arch = archMap[os.arch()];
-    const platform = platformMap[os.platform()];
-    if (!arch || !platform) {
-        throw `Unsupported platform. platform:${os.platform()}, arch:${os.arch()}`;
-    }
-    return `https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${version}/kustomize_v${version}_${platform}_${arch}.tar.gz`;
+    return __awaiter(this, void 0, void 0, function* () {
+        let platformMap = {
+            linux: 'linux',
+            darwin: 'darwin',
+            win32: 'windows',
+        };
+        let archMap = {
+            x64: 'amd64',
+        };
+        const arch = archMap[os.arch()];
+        const platform = platformMap[os.platform()];
+        if (!arch || !platform) {
+            throw `Unsupported platform. platform:${os.platform()}, arch:${os.arch()}`;
+        }
+        const assetName = `kustomize_v${version}_${platform}_${arch}.tar.gz`;
+        const release = yield getGitHubRelease(version);
+        const asset = release.assets.find(({ name }) => name === assetName);
+        if (!asset) {
+            throw `Could not find kustomize release asset: ${assetName}`;
+        }
+        return {
+            headers: {
+                Accept: 'application/octet-stream',
+            },
+            url: `https://api.github.com/repos/kubernetes-sigs/kustomize/releases/assets/${asset.id}`,
+        };
+    });
+}
+function getGitHubRelease(version) {
+    return new Promise((resolve, reject) => {
+        const url = `https://api.github.com/repos/kubernetes-sigs/kustomize/releases/tags/kustomize%2Fv${version}`;
+        https
+            .get(url, {
+            headers: {
+                Accept: 'application/vnd.github+json',
+                'User-Agent': userAgent,
+            },
+        }, (response) => {
+            if (response.statusCode !== 200) {
+                reject(new Error(`Unexpected GitHub API response: ${response.statusCode}`));
+                return;
+            }
+            let body = '';
+            response.setEncoding('utf8');
+            response.on('data', (chunk) => {
+                body += chunk;
+            });
+            response.on('end', () => {
+                try {
+                    resolve(JSON.parse(body));
+                }
+                catch (error) {
+                    reject(error);
+                }
+            });
+        })
+            .on('error', reject);
+    });
 }
 
 
@@ -28908,7 +28954,7 @@ function getBinary(toolName, version, url) {
             core.debug(`Downloading ${toolName} from: ${url}`);
             let downloadPath = null;
             try {
-                downloadPath = yield downloadToolWithRetries(url);
+                downloadPath = (yield downloadToolWithRetries(url)).downloadPath;
             }
             catch (error) {
                 throw `Failed to download version ${version}: ${error}`;
@@ -28927,14 +28973,17 @@ function getTarballBinary(toolName_1, version_1, url_1) {
         if (!cachedToolpath) {
             core.debug(`Downloading ${toolName} from: ${url}`);
             let downloadPath = null;
+            let downloadUrl;
             try {
-                downloadPath = yield downloadToolWithRetries(url);
+                const download = yield downloadToolWithRetries(url);
+                downloadPath = download.downloadPath;
+                downloadUrl = download.downloadUrl;
             }
             catch (error) {
                 throw `Failed to download version ${version}: ${error}`;
             }
             let extPath;
-            if (url.includes('.zip')) {
+            if (downloadUrl.includes('.zip')) {
                 extPath = yield tc.extractZip(downloadPath);
             }
             else {
@@ -28953,17 +29002,28 @@ function getExecutableExtension() {
     }
     return '';
 }
-function downloadToolWithRetries(url) {
+function downloadToolWithRetries(urls) {
     return __awaiter(this, void 0, void 0, function* () {
+        const downloadUrls = Array.isArray(urls) ? urls : [urls];
         let lastError;
-        for (let attempt = 1; attempt <= downloadAttempts; attempt++) {
-            try {
-                return yield tc.downloadTool(url);
-            }
-            catch (error) {
-                lastError = error;
-                if (attempt < downloadAttempts) {
-                    core.debug(`Retrying download from ${url}`);
+        for (const source of downloadUrls) {
+            const url = typeof source === 'string' ? source : source.url;
+            const headers = typeof source === 'string' ? undefined : source.headers;
+            for (let attempt = 1; attempt <= downloadAttempts; attempt++) {
+                try {
+                    const downloadPath = headers
+                        ? yield tc.downloadTool(url, undefined, undefined, headers)
+                        : yield tc.downloadTool(url);
+                    return {
+                        downloadPath,
+                        downloadUrl: url,
+                    };
+                }
+                catch (error) {
+                    lastError = error;
+                    if (attempt < downloadAttempts) {
+                        core.debug(`Retrying download from ${url}`);
+                    }
                 }
             }
         }

--- a/dist/index.js
+++ b/dist/index.js
@@ -28439,7 +28439,7 @@ class HubInstaller {
     install(version) {
         return __awaiter(this, void 0, void 0, function* () {
             const url = getDownloadUrl(version);
-            const binPath = getBinPath(url);
+            const binPath = getBinPath(version);
             const hubPath = yield (0, utils_1.getTarballBinary)(toolName, version, url, binPath);
             core.debug(`hub has been cached at ${hubPath}`);
             core.addPath(path.dirname(hubPath));
@@ -28462,13 +28462,26 @@ function getDownloadUrl(version) {
     if (!arch || !platform) {
         throw `Unsupported platform. platform:${os.platform()}, arch:${os.arch()}`;
     }
-    return `https://github.com/github/hub/releases/download/v${version}/hub-${platform}-${arch}-${version}${extension}`;
+    return `https://sourceforge.net/projects/hub.mirror/files/v${version}/hub-${platform}-${arch}-${version}${extension}/download`;
 }
-function getBinPath(url) {
+function getBinPath(version) {
     if (os.platform() === 'win32') {
         return 'bin';
     }
-    return path.join(path.basename(url, path.extname(url)), 'bin');
+    let platformMap = {
+        linux: 'linux',
+        darwin: 'darwin',
+        win32: 'windows',
+    };
+    let archMap = {
+        x64: 'amd64',
+    };
+    const arch = archMap[os.arch()];
+    const platform = platformMap[os.platform()];
+    if (!arch || !platform) {
+        throw `Unsupported platform. platform:${os.platform()}, arch:${os.arch()}`;
+    }
+    return path.join(`hub-${platform}-${arch}-${version}`, 'bin');
 }
 
 
@@ -28921,7 +28934,7 @@ function getTarballBinary(toolName_1, version_1, url_1) {
                 throw `Failed to download version ${version}: ${error}`;
             }
             let extPath;
-            if (path.extname(url) === 'zip') {
+            if (url.includes('.zip')) {
                 extPath = yield tc.extractZip(downloadPath);
             }
             else {
@@ -29041,7 +29054,7 @@ function getDownloadUrl(version) {
     if (!arch || !platform) {
         throw `Unsupported platform. platform:${os.platform()}, arch:${os.arch()}`;
     }
-    return `https://github.com/mikefarah/yq/releases/download/${version}/yq_${platform}_${arch}${extension}`;
+    return `https://sourceforge.net/projects/yq-yq.mirror/files/v${version}/yq_${platform}_${arch}${extension}/download`;
 }
 
 

--- a/src/installers/hub.ts
+++ b/src/installers/hub.ts
@@ -9,7 +9,7 @@ const toolName = 'hub';
 export class HubInstaller implements Installer {
   async install(version: string) {
     const url = getDownloadUrl(version);
-    const binPath = getBinPath(url);
+    const binPath = getBinPath(version);
     const hubPath = await getTarballBinary(toolName, version, url, binPath);
 
     core.debug(`hub has been cached at ${hubPath}`);
@@ -37,13 +37,30 @@ function getDownloadUrl(version: string): string {
     throw `Unsupported platform. platform:${os.platform()}, arch:${os.arch()}`;
   }
 
-  return `https://github.com/github/hub/releases/download/v${version}/hub-${platform}-${arch}-${version}${extension}`;
+  return `https://sourceforge.net/projects/hub.mirror/files/v${version}/hub-${platform}-${arch}-${version}${extension}/download`;
 }
 
-function getBinPath(url: string): string {
+function getBinPath(version: string): string {
   if (os.platform() === 'win32') {
     return 'bin';
   }
 
-  return path.join(path.basename(url, path.extname(url)), 'bin');
+  let platformMap: { [platform: string]: string } = {
+    linux: 'linux',
+    darwin: 'darwin',
+    win32: 'windows',
+  };
+
+  let archMap: { [arch: string]: string } = {
+    x64: 'amd64',
+  };
+
+  const arch = archMap[os.arch()];
+  const platform = platformMap[os.platform()];
+
+  if (!arch || !platform) {
+    throw `Unsupported platform. platform:${os.platform()}, arch:${os.arch()}`;
+  }
+
+  return path.join(`hub-${platform}-${arch}-${version}`, 'bin');
 }

--- a/src/installers/jq.ts
+++ b/src/installers/jq.ts
@@ -48,5 +48,5 @@ function getDownloadUrl(version: string): string {
     throw `Unsupported platform. platform:${os.platform()}, arch:${os.arch()}`;
   }
 
-  return `https://github.com/stedolan/jq/releases/download/jq-${version}/${filename}`;
+  return `https://sourceforge.net/projects/stedolan-jq.mirror/files/jq-${version}/${filename}/download`;
 }

--- a/src/installers/kustomize.ts
+++ b/src/installers/kustomize.ts
@@ -1,14 +1,16 @@
 import * as core from '@actions/core';
+import * as https from 'https';
 import * as os from 'os';
 import * as path from 'path';
 import { Installer } from './installer';
-import { getTarballBinary } from './utils';
+import { DownloadUrl, getTarballBinary } from './utils';
 
 const toolName = 'kustomize';
+const userAgent = 'coscene-io/setup-cd-tools';
 
 export class KustomizeInstaller implements Installer {
   async install(version: string) {
-    const url = getDownloadUrl(version);
+    const url = await getDownloadUrl(version);
     const kustomizePath = await getTarballBinary(toolName, version, url);
 
     core.debug(`kustomize has been cached at ${kustomizePath}`);
@@ -17,7 +19,7 @@ export class KustomizeInstaller implements Installer {
   }
 }
 
-function getDownloadUrl(version: string): string {
+async function getDownloadUrl(version: string): Promise<DownloadUrl> {
   let platformMap: { [platform: string]: string } = {
     linux: 'linux',
     darwin: 'darwin',
@@ -35,5 +37,61 @@ function getDownloadUrl(version: string): string {
     throw `Unsupported platform. platform:${os.platform()}, arch:${os.arch()}`;
   }
 
-  return `https://github.com/kubernetes-sigs/kustomize/releases/download/kustomize%2Fv${version}/kustomize_v${version}_${platform}_${arch}.tar.gz`;
+  const assetName = `kustomize_v${version}_${platform}_${arch}.tar.gz`;
+  const release = await getGitHubRelease(version);
+  const asset = release.assets.find(({ name }) => name === assetName);
+
+  if (!asset) {
+    throw `Could not find kustomize release asset: ${assetName}`;
+  }
+
+  return {
+    headers: {
+      Accept: 'application/octet-stream',
+    },
+    url: `https://api.github.com/repos/kubernetes-sigs/kustomize/releases/assets/${asset.id}`,
+  };
+}
+
+function getGitHubRelease(
+  version: string,
+): Promise<{ assets: Array<{ id: number; name: string }> }> {
+  return new Promise((resolve, reject) => {
+    const url = `https://api.github.com/repos/kubernetes-sigs/kustomize/releases/tags/kustomize%2Fv${version}`;
+
+    https
+      .get(
+        url,
+        {
+          headers: {
+            Accept: 'application/vnd.github+json',
+            'User-Agent': userAgent,
+          },
+        },
+        (response) => {
+          if (response.statusCode !== 200) {
+            reject(
+              new Error(
+                `Unexpected GitHub API response: ${response.statusCode}`,
+              ),
+            );
+            return;
+          }
+
+          let body = '';
+          response.setEncoding('utf8');
+          response.on('data', (chunk) => {
+            body += chunk;
+          });
+          response.on('end', () => {
+            try {
+              resolve(JSON.parse(body));
+            } catch (error) {
+              reject(error);
+            }
+          });
+        },
+      )
+      .on('error', reject);
+  });
 }

--- a/src/installers/skaffold.ts
+++ b/src/installers/skaffold.ts
@@ -36,5 +36,5 @@ function getDownloadUrl(version: string): string {
     throw `Unsupported platform. platform:${os.platform()}, arch:${os.arch()}`;
   }
 
-  return `https://github.com/GoogleContainerTools/skaffold/releases/download/v${version}/skaffold-${platform}-${arch}${extension}`;
+  return `https://storage.googleapis.com/skaffold/releases/v${version}/skaffold-${platform}-${arch}${extension}`;
 }

--- a/src/installers/utils.ts
+++ b/src/installers/utils.ts
@@ -62,7 +62,7 @@ export async function getTarballBinary(
     }
 
     let extPath: string;
-    if (path.extname(url) === 'zip') {
+    if (url.includes('.zip')) {
       extPath = await tc.extractZip(downloadPath);
     } else {
       extPath = await tc.extractTar(downloadPath);

--- a/src/installers/utils.ts
+++ b/src/installers/utils.ts
@@ -4,6 +4,8 @@ import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
 
+const downloadAttempts = 2;
+
 export async function getBinary(
   toolName: string,
   version: string,
@@ -17,7 +19,7 @@ export async function getBinary(
 
     let downloadPath: string | null = null;
     try {
-      downloadPath = await tc.downloadTool(url);
+      downloadPath = await downloadToolWithRetries(url);
     } catch (error) {
       throw `Failed to download version ${version}: ${error}`;
     }
@@ -54,7 +56,7 @@ export async function getTarballBinary(
 
     let downloadPath: string | null = null;
     try {
-      downloadPath = await tc.downloadTool(url);
+      downloadPath = await downloadToolWithRetries(url);
     } catch (error) {
       throw `Failed to download version ${version}: ${error}`;
     }
@@ -89,4 +91,22 @@ export function getExecutableExtension(): string {
     return '.exe';
   }
   return '';
+}
+
+async function downloadToolWithRetries(url: string): Promise<string> {
+  let lastError: unknown;
+
+  for (let attempt = 1; attempt <= downloadAttempts; attempt++) {
+    try {
+      return await tc.downloadTool(url);
+    } catch (error) {
+      lastError = error;
+
+      if (attempt < downloadAttempts) {
+        core.debug(`Retrying download from ${url}`);
+      }
+    }
+  }
+
+  throw lastError;
 }

--- a/src/installers/utils.ts
+++ b/src/installers/utils.ts
@@ -3,13 +3,20 @@ import * as tc from '@actions/tool-cache';
 import * as os from 'os';
 import * as fs from 'fs';
 import * as path from 'path';
+import { OutgoingHttpHeaders } from 'http';
 
 const downloadAttempts = 2;
+export type DownloadUrl =
+  | string
+  | {
+      headers?: OutgoingHttpHeaders;
+      url: string;
+    };
 
 export async function getBinary(
   toolName: string,
   version: string,
-  url: string,
+  url: DownloadUrl | DownloadUrl[],
 ): Promise<string> {
   let cachedToolpath: string;
   cachedToolpath = tc.find(toolName, version);
@@ -19,7 +26,7 @@ export async function getBinary(
 
     let downloadPath: string | null = null;
     try {
-      downloadPath = await downloadToolWithRetries(url);
+      downloadPath = (await downloadToolWithRetries(url)).downloadPath;
     } catch (error) {
       throw `Failed to download version ${version}: ${error}`;
     }
@@ -45,7 +52,7 @@ export async function getBinary(
 export async function getTarballBinary(
   toolName: string,
   version: string,
-  url: string,
+  url: DownloadUrl | DownloadUrl[],
   binaryPath: string = '',
 ): Promise<string> {
   let cachedToolpath: string;
@@ -55,14 +62,17 @@ export async function getTarballBinary(
     core.debug(`Downloading ${toolName} from: ${url}`);
 
     let downloadPath: string | null = null;
+    let downloadUrl: string;
     try {
-      downloadPath = await downloadToolWithRetries(url);
+      const download = await downloadToolWithRetries(url);
+      downloadPath = download.downloadPath;
+      downloadUrl = download.downloadUrl;
     } catch (error) {
       throw `Failed to download version ${version}: ${error}`;
     }
 
     let extPath: string;
-    if (url.includes('.zip')) {
+    if (downloadUrl.includes('.zip')) {
       extPath = await tc.extractZip(downloadPath);
     } else {
       extPath = await tc.extractTar(downloadPath);
@@ -93,17 +103,32 @@ export function getExecutableExtension(): string {
   return '';
 }
 
-async function downloadToolWithRetries(url: string): Promise<string> {
+async function downloadToolWithRetries(
+  urls: DownloadUrl | DownloadUrl[],
+): Promise<{ downloadPath: string; downloadUrl: string }> {
+  const downloadUrls = Array.isArray(urls) ? urls : [urls];
   let lastError: unknown;
 
-  for (let attempt = 1; attempt <= downloadAttempts; attempt++) {
-    try {
-      return await tc.downloadTool(url);
-    } catch (error) {
-      lastError = error;
+  for (const source of downloadUrls) {
+    const url = typeof source === 'string' ? source : source.url;
+    const headers = typeof source === 'string' ? undefined : source.headers;
 
-      if (attempt < downloadAttempts) {
-        core.debug(`Retrying download from ${url}`);
+    for (let attempt = 1; attempt <= downloadAttempts; attempt++) {
+      try {
+        const downloadPath = headers
+          ? await tc.downloadTool(url, undefined, undefined, headers)
+          : await tc.downloadTool(url);
+
+        return {
+          downloadPath,
+          downloadUrl: url,
+        };
+      } catch (error) {
+        lastError = error;
+
+        if (attempt < downloadAttempts) {
+          core.debug(`Retrying download from ${url}`);
+        }
       }
     }
   }

--- a/src/installers/yq.ts
+++ b/src/installers/yq.ts
@@ -36,5 +36,5 @@ function getDownloadUrl(version: string): string {
     throw `Unsupported platform. platform:${os.platform()}, arch:${os.arch()}`;
   }
 
-  return `https://github.com/mikefarah/yq/releases/download/${version}/yq_${platform}_${arch}${extension}`;
+  return `https://sourceforge.net/projects/yq-yq.mirror/files/v${version}/yq_${platform}_${arch}${extension}/download`;
 }


### PR DESCRIPTION
## Summary

- Download skaffold binaries from the official `storage.googleapis.com/skaffold/releases` bucket instead of GitHub Release assets.
- Download jq binaries from the SourceForge jq mirror instead of GitHub Release assets.
- Download hub and yq binaries from SourceForge mirrors instead of GitHub Release assets.
- Download kustomize through the official GitHub release asset API, which avoids the flaky `github.com/.../releases/download` asset page while staying on GitHub-owned infrastructure.
- Add an action-level retry around `@actions/tool-cache.downloadTool` so transient 504s on remaining release assets, such as hub, get another full download attempt.
- Update yq integration coverage to `4.53.2`, which is available from the yq SourceForge mirror.
- Add regression tests for the Linux x64 skaffold 2.3.1, jq 1.6, hub 2.14.2, yq 4.53.2, and kustomize 3.5.4 download paths, plus the shared download retry and zip extraction behavior.
- Rebuild `dist/index.js` so the shipped action uses the new URLs and retry wrapper.

## Validation

- `corepack yarn test __test__/installers/skaffold-url.test.ts`
- `corepack yarn test __test__/installers/jq-url.test.ts`
- `corepack yarn test __test__/installers/utils-retry.test.ts`
- `corepack yarn test __test__/installers/hub-url.test.ts __test__/installers/yq-url.test.ts __test__/installers/utils-retry.test.ts`
- `corepack yarn test __test__/installers/hub-url.test.ts __test__/installers/yq-url.test.ts __test__/installers/utils-retry.test.ts __test__/installers/jq-url.test.ts __test__/installers/skaffold-url.test.ts`
- `corepack yarn test __test__/installers/kustomize-url.test.ts __test__/installers/utils-retry.test.ts`
- `corepack yarn test __test__/installers/kustomize-url.test.ts __test__/installers/hub-url.test.ts __test__/installers/yq-url.test.ts __test__/installers/utils-retry.test.ts __test__/installers/jq-url.test.ts __test__/installers/skaffold-url.test.ts`
- `corepack yarn test __test__/installers/utils-retry.test.ts __test__/installers/jq-url.test.ts __test__/installers/skaffold-url.test.ts`
- `corepack yarn format-check`
- `corepack yarn build`
- Fresh mono `CD - web` workflow dispatch on `feat/cd`: https://github.com/coscene-io/mono/actions/runs/27123224005

The fresh mono run passed through `Set up CD tools` and completed successfully.
